### PR TITLE
Add configuration class for final output

### DIFF
--- a/examples/knitpy_overview.html
+++ b/examples/knitpy_overview.html
@@ -159,7 +159,7 @@ e
 </tbody>
 </table>
 </div>
-<p><code>pandas.DataFrame</code> can be represented as <code>text/plain</code> or <code>text/html</code>. Unfortunately, pandoc cannot convert <code>html</code> to <code>docx</code>. If this document is converted into <code>docx</code>, the above will be displayed as <code>text/plain</code>, which looks like the following:</p>
+<p><code>pandas.DataFrame</code> can be represented as <code>text/plain</code> or <code>text/html</code>. Unfortunately, pandoc cannot convert <code>html</code> to <code>docx</code> or <code>pdf</code>. If this document is converted into <code>docx</code>, the above will be displayed as <code>text/plain</code>, which looks like the following:</p>
 <pre class="sourceCode python"><code class="sourceCode python">pd.set_option(<span class="st">&quot;display.notebook_repr_html&quot;</span>, <span class="ot">False</span>) 
 df</code></pre>
 <pre><code>   a                    b
@@ -170,7 +170,7 @@ df</code></pre>
 4  5                    e</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="co"># set back the display </span>
 pd.set_option(<span class="st">&quot;display.notebook_repr_html&quot;</span>, <span class="ot">True</span>) </code></pre>
-<p>It’s possible to get around this limitation by using the <a href="https://bitbucket.org/astanin/python-tabulate">tabulate</a> package together with <code>results=&quot;asis&quot;</code>. Unfortunately, this still breaks in latex/pdf documents :-/</p>
+<p>It’s possible to get around this limitation by using the <a href="https://bitbucket.org/astanin/python-tabulate">tabulate</a> package together with <code>results=&quot;asis&quot;</code>.</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="ch">from</span> tabulate <span class="ch">import</span> tabulate
 <span class="ch">from</span> IPython.core.display <span class="ch">import</span> display, Markdown
 <span class="co"># either print and use `results=&quot;asis&quot;`</span>
@@ -249,7 +249,7 @@ Markdown(tabulate(df, <span class="dt">list</span>(df.columns), tablefmt=<span c
 </tr>
 </tbody>
 </table>
-<p>Make very sure that the <code>DataFrame</code> is not too long…</p>
+<p>Unfortunately, all three versions are not perfect (e.g. all have problems with wide tables in PDF, which spill over the page margin).</p>
 </div>
 <div id="error-handling" class="section level3">
 <h3>Error handling</h3>
@@ -258,7 +258,7 @@ Markdown(tabulate(df, <span class="dt">list</span>(df.columns), tablefmt=<span c
 <span class="dt">print</span>(sys.not_available)</code></pre>
 <p><strong>ERROR</strong>: AttributeError: ‘module’ object has no attribute ‘not_available’</p>
 <pre><code>AttributeError                            Traceback (most recent call last)
-&lt;ipython-input-31-a5971246c0f7&gt; in &lt;module&gt;()
+&lt;ipython-input-29-a5971246c0f7&gt; in &lt;module&gt;()
 ----&gt; 1 print(sys.not_available)
 
 AttributeError: 'module' object has no attribute 'not_available'</code></pre>

--- a/examples/knitpy_overview.html_document.md
+++ b/examples/knitpy_overview.html_document.md
@@ -159,7 +159,7 @@ df
 <div style="max-height:1000px;max-width:1500px;overflow:auto;"><table border="1" class="dataframe"><thead><tr style="text-align: right;"><th></th><th>a</th><th>b</th></tr></thead><tbody><tr><th>0</th><td> 1</td><td> This is longer text</td></tr><tr><th>1</th><td> 2</td><td> b</td></tr><tr><th>2</th><td> 3</td><td> c</td></tr><tr><th>3</th><td> 4</td><td> This is longer text</td></tr><tr><th>4</th><td> 5</td><td> e</td></tr></tbody></table></div>
 
 
-`pandas.DataFrame` can be represented as `text/plain` or `text/html`. Unfortunately, pandoc cannot convert `html` to `docx`. If this document is converted into `docx`, the above will be displayed as `text/plain`, which looks like the following:
+`pandas.DataFrame` can be represented as `text/plain` or `text/html`. Unfortunately, pandoc cannot convert `html` to `docx` or `pdf`. If this document is converted into `docx`, the above will be displayed as `text/plain`, which looks like the following:
 
 
 ``` python
@@ -182,7 +182,7 @@ pd.set_option("display.notebook_repr_html", True)
 ```
 
 
-It's possible to get around this limitation by using the [tabulate](https://bitbucket.org/astanin/python-tabulate) package together with `results="asis"`. Unfortunately, this still breaks in latex/pdf documents :-/
+It's possible to get around this limitation by using the [tabulate](https://bitbucket.org/astanin/python-tabulate) package together with `results="asis"`. 
 
 
 ``` python
@@ -216,7 +216,7 @@ Markdown(tabulate(df, list(df.columns), tablefmt="simple"))
  4    5  e
 
 
-Make very sure that the `DataFrame` is not too long...
+Unfortunately, all three versions are not perfect (e.g. all have problems with wide tables in PDF, which spill over the page margin).
 
 ### Error handling
 
@@ -233,7 +233,7 @@ print(sys.not_available)
 
 ```
 AttributeError                            Traceback (most recent call last)
-<ipython-input-31-a5971246c0f7> in <module>()
+<ipython-input-29-a5971246c0f7> in <module>()
 ----> 1 print(sys.not_available)
 
 AttributeError: 'module' object has no attribute 'not_available'

--- a/examples/knitpy_overview.pymd
+++ b/examples/knitpy_overview.pymd
@@ -84,7 +84,6 @@ shown in this case (`echo=False`).
 
 ```{python sinus, echo=False}
 # As this all produces no output, it should go into the same input section...
-%matplotlib inline
 import numpy as np
 import matplotlib.pyplot as plt
 y = np.linspace(2, 10)
@@ -111,7 +110,7 @@ df = pd.DataFrame({"a":[1,2,3,4,5],"b":[s,"b","c",s,"e"]})
 df
 ```
 
-`pandas.DataFrame` can be represented as `text/plain` or `text/html`. Unfortunately, pandoc cannot convert `html` to `docx`. If this document is converted into `docx`, the above will be displayed as `text/plain`, which looks like the following:
+`pandas.DataFrame` can be represented as `text/plain` or `text/html`. Unfortunately, pandoc cannot convert `html` to `docx` or `pdf`. If this document is converted into `docx`, the above will be displayed as `text/plain`, which looks like the following:
 
 ```{python}
 pd.set_option("display.notebook_repr_html", False) 
@@ -120,7 +119,7 @@ df
 pd.set_option("display.notebook_repr_html", True) 
 ```
 
-It's possible to get around this limitation by using the [tabulate](https://bitbucket.org/astanin/python-tabulate) package together with `results="asis"`. Unfortunately, this still breaks in latex/pdf documents :-/
+It's possible to get around this limitation by using the [tabulate](https://bitbucket.org/astanin/python-tabulate) package together with `results="asis"`. 
 
 ```{python results="asis"}
 from tabulate import tabulate
@@ -131,7 +130,7 @@ print(tabulate(df, list(df.columns), tablefmt="simple"))
 Markdown(tabulate(df, list(df.columns), tablefmt="simple"))
 ```
 
-Make very sure that the `DataFrame` is not too long...
+Unfortunately, all three versions are not perfect (e.g. all have problems with wide tables in PDF, which spill over the page margin).
 
 ### Error handling
 

--- a/knitpy/engines.py
+++ b/knitpy/engines.py
@@ -9,7 +9,7 @@ from IPython.utils.traitlets import Bool, Unicode, CaselessStrEnum, Instance
 
 
 class BaseKnitpyEngine(LoggingConfigurable):
-
+    name = "<NOT_EXISTANT>"
     kernel_name = "<NOT_EXISTANT>"
     startup_lines = ""
 
@@ -17,13 +17,35 @@ class BaseKnitpyEngine(LoggingConfigurable):
     def kernel(self):
         return self.parent._get_kernel(self)
 
+    def get_plotting_format_code(self, formats):
+        """
+        Enables the supplied plotting formats in the backend
+
+        formats : list of strings
+             the plotting formats. e.g. `["pdf", "png", "jpeg"]`
+
+        returns string
+            The code which should be run on the kernel to set the default plotting formats
+        """
+        raise NotImplementedError
+
 
 class PythonKnitpyEngine(BaseKnitpyEngine):
 
+    name = "python"
     kernel_name = "python"
-    startup_lines = """%matplotlib inline
-# Bad things happen if tracebacks have ansi escape sequences
-%colors NoColor
-"""
+    startup_lines = "# Bad things happen if tracebacks have ansi escape sequences\n" +\
+                    "%colors NoColor\n"
 
+    def get_plotting_format_code(self, formats):
+        valid_formats = ["png", "jpg", "jpeg", "pdf"]
+        code = "%matplotlib inline\n" +\
+               "from IPython.display import set_matplotlib_formats\n" +\
+               "set_matplotlib_formats({0})\n"
+        formats = [fmt for fmt in formats if fmt in valid_formats]
+        if not formats:
+            raise Exception("No valid output format found! Aborting...")
 
+        fmt_string = "', '".join(formats)
+        fmt_string = "'"+fmt_string+"'"
+        return code.format(fmt_string)

--- a/knitpy/knitpyapp.py
+++ b/knitpy/knitpyapp.py
@@ -30,9 +30,9 @@ from IPython.utils.traitlets import (
 )
 
 
-from .documents import MarkdownOutputDocument
+from .documents import TemporaryOutputDocument
 from .utils import get_by_name
-from .knitpy import DEFAULT_OUTPUT_FORMAT, VALID_OUTPUT_FORMATS, Knitpy, ParseException
+from .knitpy import DEFAULT_OUTPUT_FORMAT_NAME, VALID_OUTPUT_FORMAT_NAMES, Knitpy, ParseException
 
 
 #-----------------------------------------------------------------------------
@@ -104,7 +104,7 @@ class KnitpyApp(BaseIPythonApplication):
         return logging.INFO
 
     def _classes_default(self):
-        classes = [KnitpyApp, Knitpy, MarkdownOutputDocument, ProfileDir, ]
+        classes = [KnitpyApp, Knitpy, TemporaryOutputDocument, ProfileDir, ]
         # TODO: engines should be added here
         return classes
 
@@ -135,8 +135,8 @@ class KnitpyApp(BaseIPythonApplication):
 
     # Other configurable variables
     # '--to' ends up here
-    export_format = CaselessStrEnum(VALID_OUTPUT_FORMATS+["all"],
-        default_value=DEFAULT_OUTPUT_FORMAT,
+    export_format = CaselessStrEnum(VALID_OUTPUT_FORMAT_NAMES+["all"],
+        default_value=DEFAULT_OUTPUT_FORMAT_NAME,
         config=True,
         help="""The export format to be used."""
     )


### PR DESCRIPTION
Add a FinalOutputConfiguration class which describes the final output
and let the rest of the process use it.
    
This also enables more features of yaml description of output,
although most of the options which knitr implements are not yet
done.
    
Another aspect of this changes enables special handling for the
supported / prefered image filetypes per output (e.g. png for html,
pdf for pdf).