### PR TITLE
Fix for using filename-only path in Knitpy.render()

### DIFF
--- a/knitpy/knitpy.py
+++ b/knitpy/knitpy.py
@@ -648,6 +648,7 @@ class Knitpy(LoggingConfigurable):
 
         # expand $HOME and so on...
         filename = expand_path(filename)
+        filename = os.path.abspath(filename)
         self.log.info("Converting %s..." % filename)
 
         basedir = os.path.dirname(filename)


### PR DESCRIPTION
Closes: #12