### PR TITLE
Fix execution of loops

### DIFF
--- a/knitpy/py3compat.py
+++ b/knitpy/py3compat.py
@@ -1,0 +1,29 @@
+# coding: utf-8
+"""Compatibility tricks for Python 3.
+
+Stolen from ipython
+"""
+import os
+import sys
+
+if sys.version_info[0] >= 3:
+    PY3 = True
+
+    string_types = (str,)
+    unicode_type = str
+
+    xrange = range
+    def iteritems(d): return iter(d.items())
+    def itervalues(d): return iter(d.values())
+    getcwd = os.getcwd
+
+else:
+    PY3 = False
+
+    string_types = (str, unicode)
+    unicode_type = unicode
+    
+    xrange = xrange
+    def iteritems(d): return d.iteritems()
+    def itervalues(d): return d.itervalues()
+    getcwd = os.getcwdu

--- a/knitpy/tests/basics/invalid_code.md
+++ b/knitpy/tests/basics/invalid_code.md
@@ -19,3 +19,28 @@
 
 **ERROR**: Code invalid
 
+
+```python
+s = ""
+# after
+   # after2
+   print(test)
+```
+
+**ERROR**: Code invalid
+
+
+```python
+for i in range(x):
+
+```
+
+**ERROR**: IndentationError: expected an indented block (<ipython-input>, line 2)
+
+
+```python
+for i in range(x):
+print(i)
+```
+
+**ERROR**: Code invalid

--- a/knitpy/tests/basics/invalid_code.md_py3
+++ b/knitpy/tests/basics/invalid_code.md_py3
@@ -1,0 +1,46 @@
+# Invalid Code
+
+```python
+"text without a closing quote...
+```
+
+**ERROR**: Code invalid
+
+
+```python
+"text without a closing quote...
+```
+
+**ERROR**: Code invalid
+
+```python
+"More text without a closing quote...
+```
+
+**ERROR**: Code invalid
+
+
+```python
+s = ""
+# after
+   # after2
+   print(test)
+```
+
+**ERROR**: Code invalid
+
+
+```python
+for i in range(x):
+
+```
+
+**ERROR**: SyntaxError: unexpected EOF while parsing (<ipython-input>, line 2)
+
+
+```python
+for i in range(x):
+print(i)
+```
+
+**ERROR**: Code invalid

--- a/knitpy/tests/basics/invalid_code.pymd
+++ b/knitpy/tests/basics/invalid_code.pymd
@@ -8,3 +8,19 @@
 "text without a closing quote...
 "More text without a closing quote...
 ```
+
+```{python}
+s = ""
+# after
+   # after2
+   print(test)
+```
+
+```{python}
+for i in range(x):
+```
+
+```{python}
+for i in range(x):
+print(i)
+```

--- a/knitpy/tests/basics/loops.md
+++ b/knitpy/tests/basics/loops.md
@@ -1,0 +1,100 @@
+# Loops
+
+Problem here is that the loop + the first line is usually enough to make something valid code
+
+```python
+s = ""
+for i in range(10):
+    s += " %s" %i
+s
+```
+
+```
+## ' 0 1 2 3 4 5 6 7 8 9'
+```
+
+```python
+s = ""
+for i in range(10):
+    j = i
+    s += " %s" %j
+s
+```
+
+```
+## ' 0 1 2 3 4 5 6 7 8 9'
+```
+
+```python
+s = ""
+for i in range(10):
+   # test
+    j = i
+    # test
+# test
+    # test
+    s += " %s" %j
+s
+```
+
+```
+## ' 0 1 2 3 4 5 6 7 8 9'
+```
+
+```python
+s = ""
+for i in range(10):
+    for j in range(i):
+        s += " %s" %j
+s
+```
+
+```
+## ' 0 0 1 0 1 2 0 1 2 3 0 1 2 3 4 0 1 2 3 4 5 0 1 2 3 4 5 6 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 8'
+```
+
+```python
+s = ""
+for i in range(10):
+    for j in range(i):
+        k = j
+        s += " %s" %k
+s
+```
+
+```
+## ' 0 0 1 0 1 2 0 1 2 3 0 1 2 3 4 0 1 2 3 4 5 0 1 2 3 4 5 6 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 8'
+```
+
+```python
+s = ""
+for i in range(10):
+    for j in range(i):
+        k = j
+        s += " %s" %k
+    s += " loop"
+s
+```
+
+```
+## ' loop 0 loop 0 1 loop 0 1 2 loop 0 1 2 3 loop 0 1 2 3 4 loop 0 1 2 3 4 5 loop 0 1 2 3 4 5 6 loop 0 1 2 3 4 5 6 7 loop 0 1 2 3 4 5 6 7 8 loop'
+```
+
+```python
+ # test
+for i in range(3):
+    # test
+      #test
+    print(i)
+# text
+    print("works")
+```
+
+```
+## 0
+## works
+## 1
+## works
+## 2
+## works
+```

--- a/knitpy/tests/basics/loops.pymd
+++ b/knitpy/tests/basics/loops.pymd
@@ -1,0 +1,69 @@
+# Loops
+
+Problem here is that the loop + the first line is usually enough to make something valid code
+
+```{python}
+s = ""
+for i in range(10):
+    s += " %s" %i
+s
+```
+
+```{python}
+s = ""
+for i in range(10):
+    j = i
+    s += " %s" %j
+s
+```
+
+```{python}
+s = ""
+for i in range(10):
+   # test
+    j = i
+    # test
+# test
+    # test
+    s += " %s" %j
+s
+```
+
+
+```{python}
+s = ""
+for i in range(10):
+    for j in range(i):
+        s += " %s" %j
+s
+```
+
+```{python}
+s = ""
+for i in range(10):
+    for j in range(i):
+        k = j
+        s += " %s" %k
+s
+```
+
+```{python}
+s = ""
+for i in range(10):
+    for j in range(i):
+        k = j
+        s += " %s" %k
+    s += " loop"
+s
+```
+
+
+```{python}
+ # test
+for i in range(3):
+    # test
+      #test
+    print(i)
+# text
+    print("works")
+```

--- a/knitpy/utils.py
+++ b/knitpy/utils.py
@@ -1,10 +1,11 @@
 __author__ = 'jschulz'
 
-from IPython.utils.py3compat import string_types
+from .py3compat import string_types
 
 class _NA_DEFAULT_CLASS(object):
         pass
 _NA_DEFAULT = _NA_DEFAULT_CLASS()
+
 def get_by_name(dict_like, name, na="<n/a"):
     res = dict_like
     for part in name.split("."):


### PR DESCRIPTION
Before, a loop with more than one inner code line, was only
executing the first line in a loop as that was tagged as "valid
python" and executed and then the second line was executed (which
is valid as a single line can have more spaces in front of it
without being in a loop...

Fix this by looking at the next line if this line has the same
number of spaces (or is a comment/empty line).

Closes: #15