### PR TITLE
Fix jupyter update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,11 @@ nosetests.xml
 
 # Testing
 tmp
+rmd/
+*.ipynb
+
+# examples which do not need to be in the repo (html should be..)
+examples/knitpy_overview_files/figure-docx/
+examples/knitpy_overview_files/figure-pdf/
+examples/knitpy_overview_files/figure-tex/
+examples/knitpy_overview.tex

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,12 @@ env:
     - PATH=$TRAVIS_BUILD_DIR/pandoc:$PATH
 
 install:
-  # You may want to periodically update this, although the conda update
-  # conda line below will keep everything up-to-date.  We do this
-  # conditionally because it saves us some downloading if the version is
+  # We do this conditionally because it saves us some downloading if the version is
   # the same.
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget http://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+      wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
     else
-      wget http://repo.continuum.io/miniconda/Miniconda3-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+      wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
@@ -26,13 +24,13 @@ install:
   - conda update -q conda
 
   # install our packages
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip pyyaml matplotlib "ipython>=3.0" nose pyzmq
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip pyyaml matplotlib jupyter_client jupyter_core traitlets ipykernel  nose pyzmq
   - source activate test-environment
 
   # pandoc...
   - 'wget https://7de4dfdec62155b49b44-d726a73613a1989d29b147f20996e7c1.ssl.cf2.rackcdn.com/pandoc-1.12.3-linux-debian-x86_64.zip && unzip pandoc-1.12.3-linux-debian-x86_64.zip;'
   - export PATH=$TRAVIS_BUILD_DIR/pandoc:$PATH
-  - pip install pypandoc --use-mirrors
+  - pip install pypandoc
 
   # Useful for debugging any issues with conda
   - conda info -a

--- a/conda_env_dev_27.yml
+++ b/conda_env_dev_27.yml
@@ -1,0 +1,17 @@
+name: knitpy_27
+dependencies:
+- python=2.7
+- jupyter_client>=4
+- jupyter_core>=4
+- traitlets
+- ipykernel>=4
+- pyyaml>=3.10
+- pyzmq>=14.0
+- pandas
+- matplotlib
+- nose>=1.3
+- pip>=7.1
+- pip:
+  - pypandoc
+  - sphinx
+  - tabulate

--- a/conda_env_dev_35.yml
+++ b/conda_env_dev_35.yml
@@ -1,0 +1,17 @@
+name: knitpy_35
+dependencies:
+- python=3.5
+- jupyter_client>=4
+- jupyter_core>=4
+- traitlets
+- ipykernel>=4
+- pyyaml>=3.10
+- pyzmq>=14.0
+- pandas
+- matplotlib
+- nose>=1.3
+- pip>=7.1
+- pip:
+  - pypandoc
+  - sphinx
+  - tabulate

--- a/knitpy/__init__.py
+++ b/knitpy/__init__.py
@@ -1,1 +1,21 @@
+# encoding: utf-8
+from __future__ import absolute_import
+
 __author__ = 'jschulz'
+
+__all__ = ["knitpy", "render"]
+
+from .knitpy import Knitpy
+
+def render(filename, output=None):
+    """ Convert the filename to the given output format(s).
+
+    Returns
+    -------
+    converted_docs : list
+        List of filenames for the converted documents
+
+    """
+    kp = Knitpy()
+    return kp.render(filename, output=output)
+

--- a/knitpy/documents.py
+++ b/knitpy/documents.py
@@ -8,10 +8,10 @@ from collections import OrderedDict
 from pypandoc import convert as pandoc
 
 # Basic things from IPython
-from IPython.config.configurable import LoggingConfigurable
-from IPython.utils.traitlets import Bool, Unicode, CaselessStrEnum, List, Instance
-from IPython.utils.py3compat import iteritems
+from traitlets.config.configurable import LoggingConfigurable
+from traitlets import Bool, Unicode, CaselessStrEnum, List, Instance
 
+from .py3compat import iteritems
 from .utils import is_iterable, is_string
 
 TEXT, OUTPUT, CODE, ASIS = "text", "output", "code", "asis"
@@ -289,7 +289,7 @@ class TemporaryOutputDocument(LoggingConfigurable):
     def add_image(self, mimetype, mimedata, title=""):
         try:
             import base64
-            mimedata = base64.decodestring(mimedata)
+            mimedata = base64.decodebytes(mimedata.encode())
             # save as a file
             if not self.context is None:
                 filename = u"%s-%s.%s" % (self.context.chunk_label,

--- a/knitpy/encoding.py
+++ b/knitpy/encoding.py
@@ -1,0 +1,71 @@
+# coding: utf-8
+"""
+Utilities for dealing with text encodings
+"""
+
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2008-2012  The IPython Development Team
+#
+#  Distributed under the terms of the BSD License.  The full license is in
+#  the file COPYING, distributed as part of this software.
+#-----------------------------------------------------------------------------
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+import sys
+import locale
+import warnings
+
+# to deal with the possibility of sys.std* not being a stream at all
+def get_stream_enc(stream, default=None):
+    """Return the given stream's encoding or a default.
+
+    There are cases where ``sys.std*`` might not actually be a stream, so
+    check for the encoding attribute prior to returning it, and return
+    a default if it doesn't exist or evaluates as False. ``default``
+    is None if not provided.
+    """
+    if not hasattr(stream, 'encoding') or not stream.encoding:
+        return default
+    else:
+        return stream.encoding
+
+# Less conservative replacement for sys.getdefaultencoding, that will try
+# to match the environment.
+# Defined here as central function, so if we find better choices, we
+# won't need to make changes all over IPython.
+def getdefaultencoding(prefer_stream=True):
+    """Return IPython's guess for the default encoding for bytes as text.
+    
+    If prefer_stream is True (default), asks for stdin.encoding first,
+    to match the calling Terminal, but that is often None for subprocesses.
+    
+    Then fall back on locale.getpreferredencoding(),
+    which should be a sensible platform default (that respects LANG environment),
+    and finally to sys.getdefaultencoding() which is the most conservative option,
+    and usually ASCII on Python 2 or UTF8 on Python 3.
+    """
+    enc = None
+    if prefer_stream:
+        enc = get_stream_enc(sys.stdin)
+    if not enc or enc=='ascii':
+        try:
+            # There are reports of getpreferredencoding raising errors
+            # in some cases, which may well be fixed, but let's be conservative here.
+            enc = locale.getpreferredencoding()
+        except Exception:
+            pass
+    enc = enc or sys.getdefaultencoding()
+    # On windows `cp0` can be returned to indicate that there is no code page.
+    # Since cp0 is an invalid encoding return instead cp1252 which is the
+    # Western European default.
+    if enc == 'cp0':
+        warnings.warn(
+            "Invalid code page cp0 detected - using cp1252 instead."
+            "If cp1252 is incorrect please ensure a valid code page "
+            "is defined for the process.", RuntimeWarning)
+        return 'cp1252'
+    return enc
+
+DEFAULT_ENCODING = getdefaultencoding()

--- a/knitpy/engines.py
+++ b/knitpy/engines.py
@@ -4,8 +4,8 @@ __all__ = ["PythonKnitpyEngine"]
 
 LANGUAGE_ENGINES = []
 
-from IPython.config.configurable import LoggingConfigurable
-from IPython.utils.traitlets import Bool, Unicode, CaselessStrEnum, Instance
+from traitlets.config.configurable import LoggingConfigurable
+from traitlets import Bool, Unicode, CaselessStrEnum, Instance
 
 
 class BaseKnitpyEngine(LoggingConfigurable):

--- a/knitpy/knitpyapp.py
+++ b/knitpy/knitpyapp.py
@@ -21,34 +21,17 @@ import logging
 import glob
 import sys
 
-from IPython.core.application import BaseIPythonApplication, base_aliases, base_flags
-from IPython.core.crashhandler import CrashHandler
-from IPython.core.profiledir import ProfileDir
-from IPython.config import catch_config_error
-from IPython.utils.traitlets import (
+# TODO: fix IPython useage...
+from jupyter_core.application import JupyterApp, base_aliases, base_flags
+from traitlets.config import catch_config_error
+from traitlets import (
     Unicode, List, Bool, Type, CaselessStrEnum,
 )
 
 
 from .documents import TemporaryOutputDocument
-from .utils import get_by_name
 from .knitpy import DEFAULT_OUTPUT_FORMAT_NAME, VALID_OUTPUT_FORMAT_NAMES, Knitpy, ParseException
-
-
-#-----------------------------------------------------------------------------
-# Crash handler for this application
-#-----------------------------------------------------------------------------
-
-class KnitpyCrashHandler(CrashHandler):
-    """sys.excepthook for IPython itself, leaves a detailed report on disk."""
-
-    def __init__(self, app):
-        contact_name = "Jan Schulz"
-        contact_email = "jasc@gmx.net"
-        bug_tracker = 'https://github.com/janschulz/knitpy/issues'
-        super(KnitpyCrashHandler,self).__init__(
-            app, contact_name, contact_email, bug_tracker
-        )
+from .utils import get_by_name
 
 #-----------------------------------------------------------------------------
 # Main application
@@ -90,15 +73,13 @@ knitpy_flags.update({
 })
 
 
-class KnitpyApp(BaseIPythonApplication):
+class KnitpyApp(JupyterApp):
     """Application used to convert from markdown file type (``*.pymd``)"""
 
     name = 'knitpy'
     version = Unicode(u'0.1')
     aliases = knitpy_aliases
     flags = knitpy_flags
-
-    crash_handler_class = Type(KnitpyCrashHandler)
 
     def _log_level_default(self):
         return logging.INFO

--- a/knitpy/path.py
+++ b/knitpy/path.py
@@ -1,0 +1,172 @@
+# encoding: utf-8
+"""
+Utilities for path handling.
+"""
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import os
+import sys
+import errno
+import shutil
+import random
+
+from . import py3compat
+
+
+fs_encoding = sys.getfilesystemencoding()
+
+
+def filefind(filename, path_dirs=None):
+    """Find a file by looking through a sequence of paths.
+
+    This iterates through a sequence of paths looking for a file and returns
+    the full, absolute path of the first occurence of the file.  If no set of
+    path dirs is given, the filename is tested as is, after running through
+    :func:`expandvars` and :func:`expanduser`.  Thus a simple call::
+
+        filefind('myfile.txt')
+
+    will find the file in the current working dir, but::
+
+        filefind('~/myfile.txt')
+
+    Will find the file in the users home directory.  This function does not
+    automatically try any paths, such as the cwd or the user's home directory.
+
+    Parameters
+    ----------
+    filename : str
+        The filename to look for.
+    path_dirs : str, None or sequence of str
+        The sequence of paths to look for the file in.  If None, the filename
+        need to be absolute or be in the cwd.  If a string, the string is
+        put into a sequence and the searched.  If a sequence, walk through
+        each element and join with ``filename``, calling :func:`expandvars`
+        and :func:`expanduser` before testing for existence.
+
+    Returns
+    -------
+    Raises :exc:`IOError` or returns absolute path to file.
+    """
+
+    # If paths are quoted, abspath gets confused, strip them...
+    filename = filename.strip('"').strip("'")
+    # If the input is an absolute path, just check it exists
+    if os.path.isabs(filename) and os.path.isfile(filename):
+        return filename
+
+    if path_dirs is None:
+        path_dirs = ("",)
+    elif isinstance(path_dirs, py3compat.string_types):
+        path_dirs = (path_dirs,)
+
+    for path in path_dirs:
+        if path == '.': path = py3compat.getcwd()
+        testname = expand_path(os.path.join(path, filename))
+        if os.path.isfile(testname):
+            return os.path.abspath(testname)
+
+    raise IOError("File %r does not exist in any of the search paths: %r" %
+                  (filename, path_dirs) )
+
+
+def expand_path(s):
+    """Expand $VARS and ~names in a string, like a shell
+
+    :Examples:
+
+       In [2]: os.environ['FOO']='test'
+
+       In [3]: expand_path('variable FOO is $FOO')
+       Out[3]: 'variable FOO is test'
+    """
+    # This is a pretty subtle hack. When expand user is given a UNC path
+    # on Windows (\\server\share$\%username%), os.path.expandvars, removes
+    # the $ to get (\\server\share\%username%). I think it considered $
+    # alone an empty var. But, we need the $ to remains there (it indicates
+    # a hidden share).
+    if os.name=='nt':
+        s = s.replace('$\\', 'IPYTHON_TEMP')
+    s = os.path.expandvars(os.path.expanduser(s))
+    if os.name=='nt':
+        s = s.replace('IPYTHON_TEMP', '$\\')
+    return s
+
+
+try:
+    ENOLINK = errno.ENOLINK
+except AttributeError:
+    ENOLINK = 1998
+
+def link(src, dst):
+    """Hard links ``src`` to ``dst``, returning 0 or errno.
+
+    Note that the special errno ``ENOLINK`` will be returned if ``os.link`` isn't
+    supported by the operating system.
+    """
+
+    if not hasattr(os, "link"):
+        return ENOLINK
+    link_errno = 0
+    try:
+        os.link(src, dst)
+    except OSError as e:
+        link_errno = e.errno
+    return link_errno
+
+
+def link_or_copy(src, dst):
+    """Attempts to hardlink ``src`` to ``dst``, copying if the link fails.
+
+    Attempts to maintain the semantics of ``shutil.copy``.
+
+    Because ``os.link`` does not overwrite files, a unique temporary file
+    will be used if the target already exists, then that file will be moved
+    into place.
+    """
+
+    if os.path.isdir(dst):
+        dst = os.path.join(dst, os.path.basename(src))
+
+    link_errno = link(src, dst)
+    if link_errno == errno.EEXIST:
+        if os.stat(src).st_ino == os.stat(dst).st_ino:
+            # dst is already a hard link to the correct file, so we don't need
+            # to do anything else. If we try to link and rename the file
+            # anyway, we get duplicate files - see http://bugs.python.org/issue21876
+            return
+
+        new_dst = dst + "-temp-%04X" %(random.randint(1, 16**4), )
+        try:
+            link_or_copy(src, new_dst)
+        except:
+            try:
+                os.remove(new_dst)
+            except OSError:
+                pass
+            raise
+        os.rename(new_dst, dst)
+    elif link_errno != 0:
+        # Either link isn't supported, or the filesystem doesn't support
+        # linking, or 'src' and 'dst' are on different filesystems.
+        shutil.copy(src, dst)
+
+
+def ensure_dir_exists(path, mode=0o755):
+    """ensure that a directory exists
+    
+    If it doesn't exist, try to create it and protect against a race condition
+    if another process is doing the same.
+    
+    The default permissions are 755, which differ from os.makedirs default of 777.
+    """
+    if not os.path.exists(path):
+        try:
+            os.makedirs(path, mode=mode)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+    elif not os.path.isdir(path):
+        raise IOError("%r exists but is not a directory" % path)

--- a/knitpy/py3compat.py
+++ b/knitpy/py3compat.py
@@ -1,29 +1,331 @@
 # coding: utf-8
-"""Compatibility tricks for Python 3.
-
-Stolen from ipython
-"""
+"""Compatibility tricks for Python 3. Mainly to do with unicode."""
+import functools
 import os
 import sys
+import re
+import shutil
+import types
+
+from .encoding import DEFAULT_ENCODING
+
+def no_code(x, encoding=None):
+    return x
+
+def decode(s, encoding=None):
+    encoding = encoding or DEFAULT_ENCODING
+    return s.decode(encoding, "replace")
+
+def encode(u, encoding=None):
+    encoding = encoding or DEFAULT_ENCODING
+    return u.encode(encoding, "replace")
+
+
+def cast_unicode(s, encoding=None):
+    if isinstance(s, bytes):
+        return decode(s, encoding)
+    return s
+
+def cast_bytes(s, encoding=None):
+    if not isinstance(s, bytes):
+        return encode(s, encoding)
+    return s
+
+def buffer_to_bytes(buf):
+    """Cast a buffer or memoryview object to bytes"""
+    if isinstance(buf, memoryview):
+        return buf.tobytes()
+    if not isinstance(buf, bytes):
+        return bytes(buf)
+    return buf
+
+def _modify_str_or_docstring(str_change_func):
+    @functools.wraps(str_change_func)
+    def wrapper(func_or_str):
+        if isinstance(func_or_str, string_types):
+            func = None
+            doc = func_or_str
+        else:
+            func = func_or_str
+            doc = func.__doc__
+        
+        doc = str_change_func(doc)
+        
+        if func:
+            func.__doc__ = doc
+            return func
+        return doc
+    return wrapper
+
+def safe_unicode(e):
+    """unicode(e) with various fallbacks. Used for exceptions, which may not be
+    safe to call unicode() on.
+    """
+    try:
+        return unicode_type(e)
+    except UnicodeError:
+        pass
+
+    try:
+        return str_to_unicode(str(e))
+    except UnicodeError:
+        pass
+
+    try:
+        return str_to_unicode(repr(e))
+    except UnicodeError:
+        pass
+
+    return u'Unrecoverably corrupt evalue'
+
+# shutil.which from Python 3.4
+def _shutil_which(cmd, mode=os.F_OK | os.X_OK, path=None):
+    """Given a command, mode, and a PATH string, return the path which
+    conforms to the given mode on the PATH, or None if there is no such
+    file.
+
+    `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
+    of os.environ.get("PATH"), or can be overridden with a custom search
+    path.
+    
+    This is a backport of shutil.which from Python 3.4
+    """
+    # Check that a given file can be accessed with the correct mode.
+    # Additionally check that `file` is not a directory, as on Windows
+    # directories pass the os.access check.
+    def _access_check(fn, mode):
+        return (os.path.exists(fn) and os.access(fn, mode)
+                and not os.path.isdir(fn))
+
+    # If we're given a path with a directory part, look it up directly rather
+    # than referring to PATH directories. This includes checking relative to the
+    # current directory, e.g. ./script
+    if os.path.dirname(cmd):
+        if _access_check(cmd, mode):
+            return cmd
+        return None
+
+    if path is None:
+        path = os.environ.get("PATH", os.defpath)
+    if not path:
+        return None
+    path = path.split(os.pathsep)
+
+    if sys.platform == "win32":
+        # The current directory takes precedence on Windows.
+        if not os.curdir in path:
+            path.insert(0, os.curdir)
+
+        # PATHEXT is necessary to check on Windows.
+        pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
+        # See if the given file matches any of the expected path extensions.
+        # This will allow us to short circuit when given "python.exe".
+        # If it does match, only test that one, otherwise we have to try
+        # others.
+        if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
+            files = [cmd]
+        else:
+            files = [cmd + ext for ext in pathext]
+    else:
+        # On other platforms you don't have things like PATHEXT to tell you
+        # what file suffixes are executable, so just pass on cmd as-is.
+        files = [cmd]
+
+    seen = set()
+    for dir in path:
+        normdir = os.path.normcase(dir)
+        if not normdir in seen:
+            seen.add(normdir)
+            for thefile in files:
+                name = os.path.join(dir, thefile)
+                if _access_check(name, mode):
+                    return name
+    return None
 
 if sys.version_info[0] >= 3:
     PY3 = True
-
+    
+    # keep reference to builtin_mod because the kernel overrides that value
+    # to forward requests to a frontend.
+    def input(prompt=''):
+        return builtin_mod.input(prompt)
+    
+    builtin_mod_name = "builtins"
+    import builtins as builtin_mod
+    
+    str_to_unicode = no_code
+    unicode_to_str = no_code
+    str_to_bytes = encode
+    bytes_to_str = decode
+    cast_bytes_py2 = no_code
+    cast_unicode_py2 = no_code
+    buffer_to_bytes_py2 = no_code
+    
     string_types = (str,)
     unicode_type = str
+    
+    which = shutil.which
+    
+    def isidentifier(s, dotted=False):
+        if dotted:
+            return all(isidentifier(a) for a in s.split("."))
+        return s.isidentifier()
 
     xrange = range
     def iteritems(d): return iter(d.items())
     def itervalues(d): return iter(d.values())
     getcwd = os.getcwd
+    
+    MethodType = types.MethodType
+
+    def execfile(fname, glob, loc=None, compiler=None):
+        loc = loc if (loc is not None) else glob
+        with open(fname, 'rb') as f:
+            compiler = compiler or compile
+            exec(compiler(f.read(), fname, 'exec'), glob, loc)
+    
+    # Refactor print statements in doctests.
+    _print_statement_re = re.compile(r"\bprint (?P<expr>.*)$", re.MULTILINE)
+    def _print_statement_sub(match):
+        expr = match.groups('expr')
+        return "print(%s)" % expr
+    
+    @_modify_str_or_docstring
+    def doctest_refactor_print(doc):
+        """Refactor 'print x' statements in a doctest to print(x) style. 2to3
+        unfortunately doesn't pick up on our doctests.
+        
+        Can accept a string or a function, so it can be used as a decorator."""
+        return _print_statement_re.sub(_print_statement_sub, doc)
+    
+    # Abstract u'abc' syntax:
+    @_modify_str_or_docstring
+    def u_format(s):
+        """"{u}'abc'" --> "'abc'" (Python 3)
+        
+        Accepts a string or a function, so it can be used as a decorator."""
+        return s.format(u='')
+    
+    def get_closure(f):
+        """Get a function's closure attribute"""
+        return f.__closure__
 
 else:
     PY3 = False
-
+    
+    # keep reference to builtin_mod because the kernel overrides that value
+    # to forward requests to a frontend.
+    def input(prompt=''):
+        return builtin_mod.raw_input(prompt)
+    
+    builtin_mod_name = "__builtin__"
+    import __builtin__ as builtin_mod
+    
+    str_to_unicode = decode
+    unicode_to_str = encode
+    str_to_bytes = no_code
+    bytes_to_str = no_code
+    cast_bytes_py2 = cast_bytes
+    cast_unicode_py2 = cast_unicode
+    buffer_to_bytes_py2 = buffer_to_bytes
+    
     string_types = (str, unicode)
     unicode_type = unicode
+    
+    import re
+    _name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*$")
+    def isidentifier(s, dotted=False):
+        if dotted:
+            return all(isidentifier(a) for a in s.split("."))
+        return bool(_name_re.match(s))
     
     xrange = xrange
     def iteritems(d): return d.iteritems()
     def itervalues(d): return d.itervalues()
     getcwd = os.getcwdu
+
+    def MethodType(func, instance):
+        return types.MethodType(func, instance, type(instance))
+    
+    def doctest_refactor_print(func_or_str):
+        return func_or_str
+
+    def get_closure(f):
+        """Get a function's closure attribute"""
+        return f.func_closure
+    
+    which = _shutil_which
+
+    # Abstract u'abc' syntax:
+    @_modify_str_or_docstring
+    def u_format(s):
+        """"{u}'abc'" --> "u'abc'" (Python 2)
+        
+        Accepts a string or a function, so it can be used as a decorator."""
+        return s.format(u='u')
+
+    if sys.platform == 'win32':
+        def execfile(fname, glob=None, loc=None, compiler=None):
+            loc = loc if (loc is not None) else glob
+            scripttext = builtin_mod.open(fname).read()+ '\n'
+            # compile converts unicode filename to str assuming
+            # ascii. Let's do the conversion before calling compile
+            if isinstance(fname, unicode):
+                filename = unicode_to_str(fname)
+            else:
+                filename = fname
+            compiler = compiler or compile
+            exec(compiler(scripttext, filename, 'exec'), glob, loc)
+
+    else:
+        def execfile(fname, glob=None, loc=None, compiler=None):
+            if isinstance(fname, unicode):
+                filename = fname.encode(sys.getfilesystemencoding())
+            else:
+                filename = fname
+            where = [ns for ns in [glob, loc] if ns is not None]
+            if compiler is None:
+                builtin_mod.execfile(filename, *where)
+            else:
+                scripttext = builtin_mod.open(fname).read().rstrip() + '\n'
+                exec(compiler(scripttext, filename, 'exec'), glob, loc)
+
+
+def annotate(**kwargs):
+    """Python 3 compatible function annotation for Python 2."""
+    if not kwargs:
+        raise ValueError('annotations must be provided as keyword arguments')
+    def dec(f):
+        if hasattr(f, '__annotations__'):
+            for k, v in kwargs.items():
+                f.__annotations__[k] = v
+        else:
+            f.__annotations__ = kwargs
+        return f
+    return dec
+
+
+# Parts below taken from six:
+# Copyright (c) 2010-2013 Benjamin Peterson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    return meta("_NewBase", bases, {})

--- a/knitpy/utils.py
+++ b/knitpy/utils.py
@@ -69,7 +69,7 @@ def is_iterable(obj):
 def is_string(obj):
     return isinstance(obj, string_types)
 
-from IPython.utils.traitlets import TraitType
+from traitlets import TraitType
 import re
 class CRegExpMultiline(TraitType):
     """A casting compiled regular expression trait.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,10 @@ setup(
         ]
     },
     install_requires = [
-        'IPython>=3.0',
+        'jupyter_client',
+        'jupyter-core',
+        'traitlets',
+        'ipykernel',
         'pyzmq>=13',
         'pypandoc>=0.9.4',
         'pyyaml',


### PR DESCRIPTION
This is mainly a port to the newer jupyter version. It works with teh conda environment and hopefully also with pip (didn't test that...).

Closes: #36  -> new `knitpy.render(filename, format)` function
Closes: #34 -> use the new jupyter version for traitlets
Closes: #33  -> replaced all old code imports with new ones. This also makes knitpy incompatible with older versions of ipython, which still included the notebook/...

Partly adresses: #29 -> mimedata isn't a problem anymore, but the matplotlib stuff still is...